### PR TITLE
Fix watch-js: Set LC_NUMERIC for fswatch

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -138,7 +138,7 @@ let
     '')
     (writeShellScriptBin "watch-js" ''
       js-pipeline
-      while fswatch -1 --latency 0.1 --event Updated --recursive --exclude "^bundle-" app/static/js; do
+      while LC_NUMERIC=en_US.UTF-8 fswatch -1 --latency 0.1 --event Updated --recursive --exclude "^bundle-" app/static/js; do
         js-pipeline
       done
     '')


### PR DESCRIPTION
It didn't work for me due to --latency 0.1 with LC_NUMERIC=pl_PL.UTF-8

Related issue: https://github.com/emcrisostomo/fswatch/issues/166