### PR TITLE
feature: deleting notes without comments in note service

### DIFF
--- a/tests/services/test_note_service.py
+++ b/tests/services/test_note_service.py
@@ -1,0 +1,30 @@
+import pytest
+from shapely import Point
+from sqlalchemy import select
+
+from app.db import db_commit
+from app.models.db.note import Note
+from app.services.note_service import NoteService
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_delete_note_without_comments():
+    async with db_commit() as session:
+        note = Note(point=Point(0, 0), comments=[])
+        session.add(note)
+
+    async with db_commit() as session:
+        stmt = select(Note).where(Note.id == note.id)
+        note_selected = await session.scalar(stmt)
+
+    assert note.id == note_selected.id
+    assert len(note.comments) == 0
+
+    await NoteService.delete_notes_without_comments()
+
+    async with db_commit() as session:
+        stmt = select(Note).where(Note.id == note_selected.id)
+        note = await session.scalar(stmt)
+
+    assert note is None


### PR DESCRIPTION
Added method to delete notes without comments to the NoteService which was requested in issue #41. The sqlalchemy delete statement translated to the SQL looks like:
```
DELETE FROM note WHERE note.id IN (SELECT note.id FROM note LEFT OUTER JOIN note_comment ON note.id = note_comment.note_id WHERE note_comment.note_id IS NULL)
```