### PR TITLE
User activity chart data collecting

### DIFF
--- a/app/controllers/user.py
+++ b/app/controllers/user.py
@@ -113,7 +113,10 @@ async def index(display_name: Annotated[str, Path(min_length=1, max_length=DISPL
     groups_count = 0
     groups = ()
 
-    changesets_count_per_day = await ChangesetQuery.count_per_day_by_user_id(user.id, days=ACTIVITY_CHART_LENGTH)
+    today = utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    created_since = today - timedelta(days=ACTIVITY_CHART_LENGTH - 1)
+
+    changesets_count_per_day = await ChangesetQuery.count_per_day_by_user_id(user.id, created_since)
     dates_range = np.arange(
         created_since,
         today + timedelta(days=1),

--- a/app/controllers/user.py
+++ b/app/controllers/user.py
@@ -115,10 +115,11 @@ async def index(display_name: Annotated[str, Path(min_length=1, max_length=DISPL
 
     changesets_count_per_day = await ChangesetQuery.count_per_day_by_user_id(user.id, days=ACTIVITY_CHART_LENGTH)
     dates_range = np.arange(
-        utcnow().replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=ACTIVITY_CHART_LENGTH),
-        utcnow().replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1),
+        created_since,
+        today + timedelta(days=1),
         timedelta(days=1),
-    ).astype(datetime)
+        dtype=datetime,
+    )
     activity = np.array(
         [changesets_count_per_day.get(date.replace(tzinfo=UTC), 0) for date in dates_range], dtype=float
     )

--- a/app/queries/changeset_query.py
+++ b/app/queries/changeset_query.py
@@ -1,11 +1,12 @@
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Literal
 
 from shapely.ops import BaseGeometry
 from sqlalchemy import and_, func, null, select, text
 
 from app.db import db
+from app.lib.date_utils import utcnow
 from app.lib.options_context import apply_options_context
 from app.models.db.changeset import Changeset
 
@@ -124,3 +125,21 @@ class ChangesetQuery:
                 stmt = stmt.limit(limit)
 
             return (await session.scalars(stmt)).all()
+
+    @staticmethod
+    async def count_per_day_by_user_id(user_id: int, days: int) -> dict:
+        """
+        Count changesets per day by user id in given days past.
+        """
+        async with db() as session:
+            created_at_limit = utcnow() - timedelta(days=days)
+
+            stmt = (
+                select(
+                    func.date_trunc('day', Changeset.created_at).label('created_at_day_date'), func.count(Changeset.id)
+                )
+                .where(Changeset.user_id == user_id)
+                .where(Changeset.created_at > created_at_limit)
+                .group_by('created_at_day_date')
+            )
+            return dict((await session.execute(stmt)).all())

--- a/app/queries/changeset_query.py
+++ b/app/queries/changeset_query.py
@@ -127,13 +127,11 @@ class ChangesetQuery:
             return (await session.scalars(stmt)).all()
 
     @staticmethod
-    async def count_per_day_by_user_id(user_id: int, days: int) -> dict:
+    async def count_per_day_by_user_id(user_id: int, created_since: datetime) -> dict:
         """
-        Count changesets per day by user id in given days past.
+        Count changesets per day by user id since given date.
         """
         async with db() as session:
-            created_at_limit = utcnow() - timedelta(days=days)
-
             created_date = func.date_trunc('day', Changeset.created_at)
             stmt = (
                 select(

--- a/app/queries/changeset_query.py
+++ b/app/queries/changeset_query.py
@@ -134,12 +134,14 @@ class ChangesetQuery:
         async with db() as session:
             created_at_limit = utcnow() - timedelta(days=days)
 
+            created_date = func.date_trunc('day', Changeset.created_at)
             stmt = (
                 select(
-                    func.date_trunc('day', Changeset.created_at).label('created_at_day_date'), func.count(Changeset.id)
+                    created_date,
+                    func.count(Changeset.id),
                 )
                 .where(Changeset.user_id == user_id)
-                .where(Changeset.created_at > created_at_limit)
-                .group_by('created_at_day_date')
+                .where(created_date >= created_since)
+                .group_by(created_date)
             )
             return dict((await session.execute(stmt)).all())


### PR DESCRIPTION
This PR adds `activity` key to the user controller response, which stores values from 0 to 19 classifying activity of the user in the past 365 days. This data will be the source of truth to create an activity graph described in issue #47. I'm pushing only this part of the code, as I still don't feel comfortable with JS and don't want to stay stacked there.

The count_per_day_by_user_id method returns dict, where each key (datetime) have value (int) of count on ChangeSet.id.

The activity variable stores a NumPy array of 365 float values from 0 to 19 (only whole numbers, only the type is float).